### PR TITLE
Add sync (blocking) mode to all requests

### DIFF
--- a/core/src/main/java/com/auth0/Auth0Exception.java
+++ b/core/src/main/java/com/auth0/Auth0Exception.java
@@ -25,7 +25,7 @@
 package com.auth0;
 
 /**
- * All exceptions from Auth0
+ * Base Exception for any error found during a request to Auth0's API
  */
 public class Auth0Exception extends RuntimeException {
 

--- a/core/src/main/java/com/auth0/Auth0Exception.java
+++ b/core/src/main/java/com/auth0/Auth0Exception.java
@@ -1,7 +1,7 @@
 /*
- * RequestBodyBuildException.java
+ * Auth0Exception.java
  *
- * Copyright (c) 2015 Auth0 (http://auth0.com)
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,17 +22,18 @@
  * THE SOFTWARE.
  */
 
-package com.auth0.authentication.api;
-
-import com.auth0.Auth0Exception;
+package com.auth0;
 
 /**
- * Exception that wraps errors when creating a body for a request
+ * All exceptions from Auth0
  */
-public class RequestBodyBuildException extends Auth0Exception {
+public class Auth0Exception extends RuntimeException {
 
-    public RequestBodyBuildException(String message, Throwable cause) {
+    public Auth0Exception(String message, Throwable cause) {
         super(message, cause);
     }
 
+    public Auth0Exception(String message) {
+        super(message);
+    }
 }

--- a/core/src/main/java/com/auth0/authentication/AuthenticationAPIClient.java
+++ b/core/src/main/java/com/auth0/authentication/AuthenticationAPIClient.java
@@ -455,12 +455,8 @@ public class AuthenticationAPIClient {
         return RequestFactory.POST(url, client, mapper)
                 .addParameters(parameters);
     }
-
-    /**
-     * Perform a custom login request against the resource owner endpoint
-     * @return a request to configure and start
-     */
-    public ParameterizableRequest<Token> loginWithResourceOwner() {
+    
+    protected ParameterizableRequest<Token> loginWithResourceOwner() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment("oauth")
                 .addPathSegment("ro")

--- a/core/src/main/java/com/auth0/authentication/AuthenticationAPIClient.java
+++ b/core/src/main/java/com/auth0/authentication/AuthenticationAPIClient.java
@@ -406,7 +406,7 @@ public class AuthenticationAPIClient {
                 .addParameters(parameters);
     }
 
-    protected ParameterizableRequest<Map<String, Object>> delegation() {
+    public ParameterizableRequest<Map<String, Object>> delegation() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment("delegation")
                 .build();
@@ -432,7 +432,7 @@ public class AuthenticationAPIClient {
                 .addParameters(parameters);
     }
 
-    protected ParameterizableRequest<Void> passwordless() {
+    public ParameterizableRequest<Void> passwordless() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment("passwordless")
                 .addPathSegment("start")
@@ -447,7 +447,7 @@ public class AuthenticationAPIClient {
                 .addParameters(parameters);
     }
 
-    protected ParameterizableRequest<Token> loginWithResourceOwner() {
+    public ParameterizableRequest<Token> loginWithResourceOwner() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment("oauth")
                 .addPathSegment("ro")

--- a/core/src/main/java/com/auth0/authentication/AuthenticationAPIClient.java
+++ b/core/src/main/java/com/auth0/authentication/AuthenticationAPIClient.java
@@ -406,6 +406,11 @@ public class AuthenticationAPIClient {
                 .addParameters(parameters);
     }
 
+    /**
+     * Performs a custom <a href="https://auth0.com/docs/auth-api#!#post--delegation">delegation</a> request that will
+     * yield a delegation token.
+     * @return a request to configure and start
+     */
     public ParameterizableRequest<Map<String, Object>> delegation() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment("delegation")
@@ -432,6 +437,10 @@ public class AuthenticationAPIClient {
                 .addParameters(parameters);
     }
 
+    /**
+     * Start a custom passwordless flow
+     * @return a request to configure and start
+     */
     public ParameterizableRequest<Void> passwordless() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment("passwordless")
@@ -447,6 +456,10 @@ public class AuthenticationAPIClient {
                 .addParameters(parameters);
     }
 
+    /**
+     * Perform a custom login request against the resource owner endpoint
+     * @return a request to configure and start
+     */
     public ParameterizableRequest<Token> loginWithResourceOwner() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment("oauth")

--- a/core/src/main/java/com/auth0/authentication/AuthenticationRequest.java
+++ b/core/src/main/java/com/auth0/authentication/AuthenticationRequest.java
@@ -24,6 +24,7 @@
 
 package com.auth0.authentication;
 
+import com.auth0.Auth0Exception;
 import com.auth0.authentication.api.ParameterBuilder;
 import com.auth0.authentication.api.ParameterizableRequest;
 import com.auth0.authentication.api.Request;
@@ -98,14 +99,14 @@ public class AuthenticationRequest implements Request<Authentication> {
                             }
 
                             @Override
-                            public void onFailure(Throwable error) {
+                            public void onFailure(Auth0Exception error) {
                                 callback.onFailure(error);
                             }
                         });
             }
 
             @Override
-            public void onFailure(Throwable error) {
+            public void onFailure(Auth0Exception error) {
                 callback.onFailure(error);
             }
         });
@@ -114,10 +115,10 @@ public class AuthenticationRequest implements Request<Authentication> {
     /**
      * Executes the log in request and then fetches the user's profile
      * @return authentication object on success
-     * @throws Throwable on failure
+     * @throws Auth0Exception on failure
      */
     @Override
-    public Authentication execute() throws Throwable {
+    public Authentication execute() throws Auth0Exception {
         Token token = credentialsRequest.execute();
         Map<String, Object> parameters = new ParameterBuilder()
                 .clearAll()

--- a/core/src/main/java/com/auth0/authentication/AuthenticationRequest.java
+++ b/core/src/main/java/com/auth0/authentication/AuthenticationRequest.java
@@ -110,4 +110,22 @@ public class AuthenticationRequest implements Request<Authentication> {
             }
         });
     }
+
+    /**
+     * Executes the log in request and then fetches the user's profile
+     * @return authentication object on success
+     * @throws Throwable on failure
+     */
+    @Override
+    public Authentication execute() throws Throwable {
+        Token token = credentialsRequest.execute();
+        Map<String, Object> parameters = new ParameterBuilder()
+                .clearAll()
+                .set("id_token", token.getIdToken())
+                .asDictionary();
+        UserProfile profile = tokenInfoRequest
+                .addParameters(parameters)
+                .execute();
+        return new Authentication(profile, token);
+    }
 }

--- a/core/src/main/java/com/auth0/authentication/AuthenticationRequest.java
+++ b/core/src/main/java/com/auth0/authentication/AuthenticationRequest.java
@@ -113,9 +113,9 @@ public class AuthenticationRequest implements Request<Authentication> {
     }
 
     /**
-     * Executes the log in request and then fetches the user's profile
-     * @return authentication object on success
-     * @throws Auth0Exception on failure
+     * Logs in the user with Auth0 and fetches it's profile.
+     * @return authentication object containing the user's tokens and profile
+     * @throws Auth0Exception when either authentication or profile fetch fails
      */
     @Override
     public Authentication execute() throws Auth0Exception {

--- a/core/src/main/java/com/auth0/authentication/ChangePasswordRequest.java
+++ b/core/src/main/java/com/auth0/authentication/ChangePasswordRequest.java
@@ -83,7 +83,7 @@ public class ChangePasswordRequest implements ParameterizableRequest<Void> {
     }
 
     /**
-     * Performs the HTTP request against Auth0 API
+     * Starts the change password request
      * @param callback called either on success or failure
      */
     @Override
@@ -92,9 +92,9 @@ public class ChangePasswordRequest implements ParameterizableRequest<Void> {
     }
 
     /**
-     * Executes the HTTP request against Auth0 API
-     * @return Void on success
-     * @throws Auth0Exception on failure
+     * Executes the change password request
+     * @return nothing on success
+     * @throws Auth0Exception when the change password request fails
      */
     @Override
     public Void execute() throws Auth0Exception {

--- a/core/src/main/java/com/auth0/authentication/ChangePasswordRequest.java
+++ b/core/src/main/java/com/auth0/authentication/ChangePasswordRequest.java
@@ -24,6 +24,7 @@
 
 package com.auth0.authentication;
 
+import com.auth0.Auth0Exception;
 import com.auth0.authentication.api.ParameterizableRequest;
 import com.auth0.authentication.api.callback.BaseCallback;
 
@@ -93,10 +94,10 @@ public class ChangePasswordRequest implements ParameterizableRequest<Void> {
     /**
      * Executes the HTTP request against Auth0 API
      * @return Void on success
-     * @throws Throwable on failure
+     * @throws Auth0Exception on failure
      */
     @Override
-    public Void execute() throws Throwable {
+    public Void execute() throws Auth0Exception {
         return request.execute();
     }
 }

--- a/core/src/main/java/com/auth0/authentication/ChangePasswordRequest.java
+++ b/core/src/main/java/com/auth0/authentication/ChangePasswordRequest.java
@@ -89,4 +89,14 @@ public class ChangePasswordRequest implements ParameterizableRequest<Void> {
     public void start(final BaseCallback<Void> callback) {
         request.start(callback);
     }
+
+    /**
+     * Executes the HTTP request against Auth0 API
+     * @return Void on success
+     * @throws Throwable on failure
+     */
+    @Override
+    public Void execute() throws Throwable {
+        return request.execute();
+    }
 }

--- a/core/src/main/java/com/auth0/authentication/DelegationRequest.java
+++ b/core/src/main/java/com/auth0/authentication/DelegationRequest.java
@@ -34,7 +34,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Represent a delegation request for Auth0 tokens that will yield a new 'id_token'
+ * Represents a delegation request for Auth0 tokens that will yield a new delegation token.
+ * The delegation response depends on the 'api_type' parameter.
+ * @param <T> type of object that will hold the delegation response. When requesting Auth0’s 'id_token' you can
+ *           use {@link Delegation}, otherwise you’ll need to provide an object that can be created from the JSON
+ *           payload or just use {@code Map<String, Object>}
  */
 public class DelegationRequest<T> implements Request<T> {
 
@@ -66,7 +70,7 @@ public class DelegationRequest<T> implements Request<T> {
     }
 
     /**
-     * Set the api_type parameter to be sent in the request
+     * Set the 'api_type' parameter to be sent in the request
      * @param apiType the delegation api type
      * @return itself
      */
@@ -75,7 +79,7 @@ public class DelegationRequest<T> implements Request<T> {
     }
 
     /**
-     * Set the scope used to make the delegation
+     * Set the 'scope' used to make the delegation
      * @param scope value
      * @return itself
      */
@@ -84,7 +88,7 @@ public class DelegationRequest<T> implements Request<T> {
     }
 
     /**
-     * Set the target parameter to be sent in the request
+     * Set the 'target' parameter to be sent in the request
      * @param target the delegation target
      * @return itself
      */
@@ -93,7 +97,7 @@ public class DelegationRequest<T> implements Request<T> {
     }
 
     /**
-     * Performs the HTTP request against Auth0 API
+     * Starts the delegation request against Auth0 API
      * @param callback called either on success or failure
      */
     @Override
@@ -102,9 +106,9 @@ public class DelegationRequest<T> implements Request<T> {
     }
 
     /**
-     * Executes the HTTP request against Auth0 API
+     * Executes the delegation request against Auth0 API
      * @return the delegation response on success
-     * @throws Auth0Exception on failure
+     * @throws Auth0Exception when the delegation request fails
      */
     @Override
     public T execute() throws Auth0Exception {

--- a/core/src/main/java/com/auth0/authentication/DelegationRequest.java
+++ b/core/src/main/java/com/auth0/authentication/DelegationRequest.java
@@ -24,6 +24,7 @@
 
 package com.auth0.authentication;
 
+import com.auth0.Auth0Exception;
 import com.auth0.authentication.api.ParameterBuilder;
 import com.auth0.authentication.api.ParameterizableRequest;
 import com.auth0.authentication.api.Request;
@@ -103,10 +104,10 @@ public class DelegationRequest<T> implements Request<T> {
     /**
      * Executes the HTTP request against Auth0 API
      * @return the delegation response on success
-     * @throws Throwable on failure
+     * @throws Auth0Exception on failure
      */
     @Override
-    public T execute() throws Throwable {
+    public T execute() throws Auth0Exception {
         return request.execute();
     }
 }

--- a/core/src/main/java/com/auth0/authentication/DelegationRequest.java
+++ b/core/src/main/java/com/auth0/authentication/DelegationRequest.java
@@ -99,4 +99,14 @@ public class DelegationRequest<T> implements Request<T> {
     public void start(final BaseCallback<T> callback) {
         request.start(callback);
     }
+
+    /**
+     * Executes the HTTP request against Auth0 API
+     * @return the delegation response on success
+     * @throws Throwable on failure
+     */
+    @Override
+    public T execute() throws Throwable {
+        return request.execute();
+    }
 }

--- a/core/src/main/java/com/auth0/authentication/SignUpRequest.java
+++ b/core/src/main/java/com/auth0/authentication/SignUpRequest.java
@@ -24,6 +24,7 @@
 
 package com.auth0.authentication;
 
+import com.auth0.Auth0Exception;
 import com.auth0.authentication.api.ParameterizableRequest;
 import com.auth0.authentication.api.Request;
 import com.auth0.authentication.api.callback.BaseCallback;
@@ -98,7 +99,7 @@ public class SignUpRequest implements Request<Authentication> {
             }
 
             @Override
-            public void onFailure(Throwable error) {
+            public void onFailure(Auth0Exception error) {
                 callback.onFailure(error);
             }
         });
@@ -107,10 +108,10 @@ public class SignUpRequest implements Request<Authentication> {
     /**
      * Execute the create user request and then logs the user in.
      * @return authentication object on success
-     * @throws Throwable on failure
+     * @throws Auth0Exception on failure
      */
     @Override
-    public Authentication execute() throws Throwable {
+    public Authentication execute() throws Auth0Exception {
         signUpRequest.execute();
         return authenticationRequest.execute();
     }

--- a/core/src/main/java/com/auth0/authentication/SignUpRequest.java
+++ b/core/src/main/java/com/auth0/authentication/SignUpRequest.java
@@ -103,4 +103,15 @@ public class SignUpRequest implements Request<Authentication> {
             }
         });
     }
+
+    /**
+     * Execute the create user request and then logs the user in.
+     * @return authentication object on success
+     * @throws Throwable on failure
+     */
+    @Override
+    public Authentication execute() throws Throwable {
+        signUpRequest.execute();
+        return authenticationRequest.execute();
+    }
 }

--- a/core/src/main/java/com/auth0/authentication/api/APIException.java
+++ b/core/src/main/java/com/auth0/authentication/api/APIException.java
@@ -24,13 +24,15 @@
 
 package com.auth0.authentication.api;
 
+import com.auth0.Auth0Exception;
+
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Internal exception raised when a request to the API fails
  */
-public class APIClientException extends RuntimeException {
+public class APIException extends Auth0Exception {
 
     private int statusCode;
 
@@ -41,7 +43,7 @@ public class APIClientException extends RuntimeException {
      * @param detailMessage error message
      * @param throwable the cause of the exception
      */
-    public APIClientException(String detailMessage, Throwable throwable) {
+    public APIException(String detailMessage, Throwable throwable) {
         super(detailMessage, throwable);
         this.statusCode = -1;
         this.responseError = new HashMap<>();
@@ -53,7 +55,7 @@ public class APIClientException extends RuntimeException {
      * @param statusCode status code returned by the server
      * @param responseError payload of the error returned by the server
      */
-    public APIClientException(String detailMessage, int statusCode, Map<String, Object> responseError) {
+    public APIException(String detailMessage, int statusCode, Map<String, Object> responseError) {
         super(detailMessage);
         this.statusCode = statusCode;
         this.responseError = responseError != null ? responseError : new HashMap<String, Object>();
@@ -66,7 +68,7 @@ public class APIClientException extends RuntimeException {
      * @param statusCode status code returned by the server
      * @param responseError payload of the error returned by the server
      */
-    public APIClientException(String detailMessage, Throwable throwable, int statusCode, Map<String, Object> responseError) {
+    public APIException(String detailMessage, Throwable throwable, int statusCode, Map<String, Object> responseError) {
         super(detailMessage, throwable);
         this.statusCode = statusCode;
         this.responseError = responseError != null ? responseError : new HashMap<String, Object>();

--- a/core/src/main/java/com/auth0/authentication/api/Request.java
+++ b/core/src/main/java/com/auth0/authentication/api/Request.java
@@ -32,5 +32,16 @@ import com.auth0.authentication.api.callback.BaseCallback;
  */
 public interface Request<T> {
 
+    /**
+     * Performs an async HTTP request against Auth0 API
+     * @param callback called either on success or failure
+     */
     void start(BaseCallback<T> callback);
+
+    /**
+     * Executes the HTTP request against Auth0 API (blocking the current thread)
+     * @return the response on success
+     * @throws Throwable on failure
+     */
+    T execute() throws Throwable;
 }

--- a/core/src/main/java/com/auth0/authentication/api/Request.java
+++ b/core/src/main/java/com/auth0/authentication/api/Request.java
@@ -24,6 +24,7 @@
 
 package com.auth0.authentication.api;
 
+import com.auth0.Auth0Exception;
 import com.auth0.authentication.api.callback.BaseCallback;
 
 /**
@@ -41,7 +42,7 @@ public interface Request<T> {
     /**
      * Executes the HTTP request against Auth0 API (blocking the current thread)
      * @return the response on success
-     * @throws Throwable on failure
+     * @throws Auth0Exception on failure
      */
-    T execute() throws Throwable;
+    T execute() throws Auth0Exception;
 }

--- a/core/src/main/java/com/auth0/authentication/api/callback/Callback.java
+++ b/core/src/main/java/com/auth0/authentication/api/callback/Callback.java
@@ -24,6 +24,8 @@
 
 package com.auth0.authentication.api.callback;
 
+import com.auth0.Auth0Exception;
+
 /**
  * Interface for all callbacks used with Auth0 API clients
  */
@@ -31,8 +33,8 @@ public interface Callback {
 
     /**
      * Method called on Auth0 API request failure
-     * @param error Error with the reason of the failure
+     * @param error Auth0Exception with the reason of the failure
      */
-    void onFailure(Throwable error);
+    void onFailure(Auth0Exception error);
 
 }

--- a/core/src/main/java/com/auth0/authentication/api/internal/SimpleRequest.java
+++ b/core/src/main/java/com/auth0/authentication/api/internal/SimpleRequest.java
@@ -67,7 +67,7 @@ class SimpleRequest<T> extends BaseRequest<T> implements ParameterizableRequest<
             final InputStream byteStream = response.body().byteStream();
             T payload = getReader().readValue(byteStream);
             postOnSuccess(payload);
-        } catch (Exception e) {
+        } catch (IOException e) {
             postOnFailure(new Auth0Exception("Failed to parse response to request to " + url, e));
         }
     }
@@ -98,7 +98,7 @@ class SimpleRequest<T> extends BaseRequest<T> implements ParameterizableRequest<
         try {
             final InputStream byteStream = response.body().byteStream();
             return getReader().readValue(byteStream);
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new Auth0Exception("Failed to parse response to request to " + url, e);
         }
     }

--- a/core/src/main/java/com/auth0/authentication/api/internal/VoidRequest.java
+++ b/core/src/main/java/com/auth0/authentication/api/internal/VoidRequest.java
@@ -26,7 +26,6 @@ package com.auth0.authentication.api.internal;
 
 import com.auth0.Auth0Exception;
 import com.auth0.authentication.api.APIException;
-import com.auth0.authentication.api.RequestBodyBuildException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.squareup.okhttp.Callback;

--- a/core/src/test/java/com/auth0/authentication/AuthenticationAPIClientTest.java
+++ b/core/src/test/java/com/auth0/authentication/AuthenticationAPIClientTest.java
@@ -25,12 +25,8 @@
 package com.auth0.authentication;
 
 
+import com.auth0.*;
 import com.auth0.authentication.api.ParameterBuilder;
-import com.auth0.Application;
-import com.auth0.Auth0;
-import com.auth0.DatabaseUser;
-import com.auth0.Token;
-import com.auth0.UserProfile;
 import com.auth0.authentication.api.util.AuthenticationAPI;
 import com.auth0.authentication.api.util.MockBaseCallback;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -98,7 +94,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldLoadApplicationInfoFromConfigurationUrlSync() throws Throwable {
+    public void shouldLoadApplicationInfoFromConfigurationUrlSync() throws Exception {
         mockAPI.willReturnValidApplicationResponse();
 
         final Application application = client
@@ -122,16 +118,16 @@ public class AuthenticationAPIClientTest {
     public void shoulFailWithInvalidJSONSync() throws Exception {
         mockAPI.willReturnApplicationResponseWithBody("Auth0Client.set({ })", 200);
 
-        Throwable throwable = null;
+        Exception exception = null;
         try {
             client
                     .fetchApplicationInfo()
                     .execute();
-        } catch (Throwable e) {
-            throwable = e;
+        } catch (Auth0Exception e) {
+            exception = e;
         }
 
-        assertThat(throwable, is(notNullValue()));
+        assertThat(exception, is(notNullValue()));
     }
 
     @Test
@@ -147,16 +143,16 @@ public class AuthenticationAPIClientTest {
     public void shoulFailWithInvalidJSONPSync() throws Exception {
         mockAPI.willReturnApplicationResponseWithBody("INVALID_JSONP", 200);
 
-        Throwable throwable = null;
+        Exception exception = null;
         try {
             client
                     .fetchApplicationInfo()
                     .execute();
-        } catch (Throwable e) {
-            throwable = e;
+        } catch (Auth0Exception e) {
+            exception = e;
         }
 
-        assertThat(throwable, is(notNullValue()));
+        assertThat(exception, is(notNullValue()));
     }
 
     @Test
@@ -174,16 +170,16 @@ public class AuthenticationAPIClientTest {
     public void shouldFailWithFailedStatusCodeSync() throws Exception {
         mockAPI.willReturnApplicationResponseWithBody("Not Found", 404);
 
-        Throwable throwable = null;
+        Exception exception = null;
         try {
             client
                     .fetchApplicationInfo()
                     .execute();
-        } catch (Throwable e) {
-            throwable = e;
+        } catch (Auth0Exception e) {
+            exception = e;
         }
 
-        assertThat(throwable, is(notNullValue()));
+        assertThat(exception, is(notNullValue()));
     }
 
     @Test
@@ -216,7 +212,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldLoginWithResourceOwnerSync() throws Throwable {
+    public void shouldLoginWithResourceOwnerSync() throws Exception {
         mockAPI.willReturnSuccessfulLogin();
 
         final Map<String, Object> parameters = ParameterBuilder.newBuilder()
@@ -275,16 +271,16 @@ public class AuthenticationAPIClientTest {
                 .set("password", "notapassword")
                 .asDictionary();
 
-        Throwable throwable = null;
+        Exception exception = null;
         try {
             client.loginWithResourceOwner()
                     .addParameters(parameters)
                     .execute();
-        } catch (Throwable e) {
-            throwable = e;
+        } catch (Auth0Exception e) {
+            exception = e;
         }
 
-        assertThat(throwable, is(notNullValue()));
+        assertThat(exception, is(notNullValue()));
     }
 
     @Test
@@ -301,7 +297,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldLoginWithUserAndPasswordSync() throws Throwable {
+    public void shouldLoginWithUserAndPasswordSync() throws Exception {
         mockAPI
                 .willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
@@ -328,7 +324,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldFetchTokenInfoSync() throws Throwable {
+    public void shouldFetchTokenInfoSync() throws Exception {
         mockAPI.willReturnTokenInfo();
 
         final UserProfile profile = client
@@ -363,7 +359,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldLoginWithOAuthAccessTokenSync() throws Throwable {
+    public void shouldLoginWithOAuthAccessTokenSync() throws Exception {
         mockAPI
                 .willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
@@ -406,7 +402,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldLoginWithPhoneNumberSync() throws Throwable {
+    public void shouldLoginWithPhoneNumberSync() throws Exception {
         mockAPI
                 .willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
@@ -450,7 +446,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldLoginWithEmailOnlySync() throws Throwable {
+    public void shouldLoginWithEmailOnlySync() throws Exception {
         mockAPI
                 .willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
@@ -491,7 +487,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldCreateUserSync() throws Throwable {
+    public void shouldCreateUserSync() throws Exception {
         mockAPI.willReturnSuccessfulSignUp();
 
         final DatabaseUser user = client
@@ -529,7 +525,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldCreateUserWithoutUsernameSync() throws Throwable {
+    public void shouldCreateUserWithoutUsernameSync() throws Exception {
         mockAPI.willReturnSuccessfulSignUp();
 
         final DatabaseUser user = client
@@ -569,7 +565,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSignUpUserSync() throws Throwable {
+    public void shouldSignUpUserSync() throws Exception {
         mockAPI.willReturnSuccessfulSignUp()
                 .willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
@@ -611,7 +607,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSignUpUserWithoutUsernameSync() throws Throwable {
+    public void shouldSignUpUserWithoutUsernameSync() throws Exception {
         mockAPI.willReturnSuccessfulSignUp()
                 .willReturnSuccessfulLogin()
                 .willReturnTokenInfo();
@@ -652,7 +648,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldChangePasswordSync() throws Throwable {
+    public void shouldChangePasswordSync() throws Exception {
         mockAPI.willReturnSuccessfulChangePassword();
 
         client.changePassword("support@auth0.com")
@@ -688,7 +684,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldRequestChangePasswordSync() throws Throwable {
+    public void shouldRequestChangePasswordSync() throws Exception {
         mockAPI.willReturnSuccessfulChangePassword();
 
         client.changePassword("support@auth0.com")
@@ -724,7 +720,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldCallDelegationSync() throws Throwable {
+    public void shouldCallDelegationSync() throws Exception {
         mockAPI.willReturnGenericDelegationToken();
 
         final Map<String, Object> response = client
@@ -764,7 +760,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldGetNewIdTokenWithIdTokenSync() throws Throwable {
+    public void shouldGetNewIdTokenWithIdTokenSync() throws Exception {
         mockAPI.willReturnNewIdToken();
 
         final Delegation delegation = client
@@ -804,7 +800,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldGetNewIdTokenWithRefreshTokenSync() throws Throwable {
+    public void shouldGetNewIdTokenWithRefreshTokenSync() throws Exception {
         mockAPI.willReturnNewIdToken();
 
         final Delegation delegation = client
@@ -846,7 +842,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldGetCustomizedDelegationRequestSync() throws Throwable {
+    public void shouldGetCustomizedDelegationRequestSync() throws Exception {
         mockAPI.willReturnNewIdToken();
 
         client
@@ -887,7 +883,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldUnlinkAccountSync() throws Throwable {
+    public void shouldUnlinkAccountSync() throws Exception {
         mockAPI.willReturnSuccessfulUnlinkAccount();
 
         client.unlink("user id", "access token")
@@ -930,7 +926,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldStartPasswordlessSync() throws Throwable {
+    public void shouldStartPasswordlessSync() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
         final Map<String, Object> parameters = new ParameterBuilder()
@@ -975,7 +971,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSendEmailCodeSync() throws Throwable {
+    public void shouldSendEmailCodeSync() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
         client.passwordlessWithEmail("support@auth0.com", PasswordlessType.CODE)
@@ -1012,7 +1008,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSendEmailLinkSync() throws Throwable {
+    public void shouldSendEmailLinkSync() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
         client.passwordlessWithEmail("support@auth0.com", PasswordlessType.LINK)
@@ -1049,7 +1045,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSendEmailLinkAndroidSync() throws Throwable {
+    public void shouldSendEmailLinkAndroidSync() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
         client.passwordlessWithEmail("support@auth0.com", PasswordlessType.LINK_ANDROID)
@@ -1086,7 +1082,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSendEmailLinkIOSSync() throws Throwable {
+    public void shouldSendEmailLinkIOSSync() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
         client.passwordlessWithEmail("support@auth0.com", PasswordlessType.LINK_IOS)
@@ -1123,7 +1119,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSendSMSCodeSync() throws Throwable {
+    public void shouldSendSMSCodeSync() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
         client.passwordlessWithSMS("+1123123123", PasswordlessType.CODE)
@@ -1160,7 +1156,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSendSMSLinkSync() throws Throwable {
+    public void shouldSendSMSLinkSync() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
         client.passwordlessWithSMS("+1123123123", PasswordlessType.LINK)
@@ -1197,7 +1193,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSendSMSLinkAndroidSync() throws Throwable {
+    public void shouldSendSMSLinkAndroidSync() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
         client.passwordlessWithSMS("+1123123123", PasswordlessType.LINK_ANDROID)
@@ -1234,7 +1230,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldSendSMSLinkIOSSync() throws Throwable {
+    public void shouldSendSMSLinkIOSSync() throws Exception {
         mockAPI.willReturnSuccessfulPasswordlessStart();
 
         client.passwordlessWithSMS("+1123123123", PasswordlessType.LINK_IOS)

--- a/core/src/test/java/com/auth0/authentication/AuthenticationAPIClientTest.java
+++ b/core/src/test/java/com/auth0/authentication/AuthenticationAPIClientTest.java
@@ -780,6 +780,50 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
+    public void shouldGetCustomizedDelegationRequestWithIdToken() throws Exception {
+        mockAPI.willReturnNewIdToken();
+
+        final MockBaseCallback<Map<String,Object>> callback = new MockBaseCallback<>();
+        client.delegationWithIdToken(ID_TOKEN, "custom_api_type")
+                .setScope("custom_scope")
+                .setTarget("custom_target")
+                .start(callback);
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getPath(), equalTo("/delegation"));
+
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("grant_type", ParameterBuilder.GRANT_TYPE_JWT));
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("api_type", "custom_api_type"));
+        assertThat(body, hasEntry("scope", "custom_scope"));
+        assertThat(body, hasEntry("target", "custom_target"));
+        assertThat(body, hasEntry("id_token", ID_TOKEN));
+    }
+
+    @Test
+    public void shouldGetCustomizedDelegationRequestWithIdTokenSync() throws Exception {
+        mockAPI.willReturnNewIdToken();
+
+        client
+                .delegationWithIdToken(ID_TOKEN, "custom_api_type")
+                .setScope("custom_scope")
+                .setTarget("custom_target")
+                .execute();
+
+        final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getPath(), equalTo("/delegation"));
+
+        Map<String, String> body = bodyFromRequest(request);
+        assertThat(body, hasEntry("grant_type", ParameterBuilder.GRANT_TYPE_JWT));
+        assertThat(body, hasEntry("client_id", CLIENT_ID));
+        assertThat(body, hasEntry("api_type", "custom_api_type"));
+        assertThat(body, hasEntry("scope", "custom_scope"));
+        assertThat(body, hasEntry("target", "custom_target"));
+        assertThat(body, hasEntry("id_token", ID_TOKEN));
+    }
+
+    @Test
     public void shouldGetNewIdTokenWithRefreshToken() throws Exception {
         mockAPI.willReturnNewIdToken();
 
@@ -820,7 +864,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldGetCustomizedDelegationRequest() throws Exception {
+    public void shouldGetCustomizedDelegationRequestWithRefreshToken() throws Exception {
         mockAPI.willReturnNewIdToken();
 
         final MockBaseCallback<Map<String,Object>> callback = new MockBaseCallback<>();
@@ -842,7 +886,7 @@ public class AuthenticationAPIClientTest {
     }
 
     @Test
-    public void shouldGetCustomizedDelegationRequestSync() throws Exception {
+    public void shouldGetCustomizedDelegationRequestWithRefreshTokenSync() throws Exception {
         mockAPI.willReturnNewIdToken();
 
         client

--- a/core/src/test/java/com/auth0/authentication/api/internal/BaseRequestTest.java
+++ b/core/src/test/java/com/auth0/authentication/api/internal/BaseRequestTest.java
@@ -70,6 +70,11 @@ public class BaseRequestTest {
         HttpUrl url = HttpUrl.parse("https://auth0.com");
         baseRequest = new BaseRequest<String>(url, client, reader, writer, callback) {
             @Override
+            public String execute() throws Throwable {
+                return null;
+            }
+
+            @Override
             public void onResponse(Response response) throws IOException {
 
             }

--- a/core/src/test/java/com/auth0/authentication/api/internal/BaseRequestTest.java
+++ b/core/src/test/java/com/auth0/authentication/api/internal/BaseRequestTest.java
@@ -25,6 +25,7 @@
 package com.auth0.authentication.api.internal;
 
 
+import com.auth0.Auth0Exception;
 import com.auth0.authentication.api.RequestBodyBuildException;
 import com.auth0.authentication.api.callback.BaseCallback;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -54,11 +55,13 @@ public class BaseRequestTest {
     @Mock
     private BaseCallback<String> callback;
     @Mock
-    private Throwable throwable;
+    private Auth0Exception throwable;
     @Mock
     private OkHttpClient client;
     @Mock
     private ObjectReader reader;
+    @Mock
+    private ObjectReader errorReader;
     @Mock
     private ObjectWriter writer;
     @Captor
@@ -68,9 +71,9 @@ public class BaseRequestTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         HttpUrl url = HttpUrl.parse("https://auth0.com");
-        baseRequest = new BaseRequest<String>(url, client, reader, writer, callback) {
+        baseRequest = new BaseRequest<String>(url, client, reader, errorReader, writer, callback) {
             @Override
-            public String execute() throws Throwable {
+            public String execute() throws Auth0Exception {
                 return null;
             }
 

--- a/core/src/test/java/com/auth0/authentication/api/util/MockBaseCallback.java
+++ b/core/src/test/java/com/auth0/authentication/api/util/MockBaseCallback.java
@@ -24,6 +24,7 @@
 
 package com.auth0.authentication.api.util;
 
+import com.auth0.Auth0Exception;
 import com.auth0.authentication.api.callback.BaseCallback;
 
 import java.util.concurrent.Callable;
@@ -31,7 +32,7 @@ import java.util.concurrent.Callable;
 public class MockBaseCallback<T> implements BaseCallback<T> {
 
     private T payload;
-    private Throwable error;
+    private Auth0Exception error;
 
     @Override
     public void onSuccess(T payload) {
@@ -39,7 +40,7 @@ public class MockBaseCallback<T> implements BaseCallback<T> {
     }
 
     @Override
-    public void onFailure(Throwable error) {
+    public void onFailure(Auth0Exception error) {
         this.error = error;
     }
 
@@ -52,10 +53,10 @@ public class MockBaseCallback<T> implements BaseCallback<T> {
         };
     }
 
-    public Callable<Throwable> error() {
-        return new Callable<Throwable>() {
+    public Callable<Auth0Exception> error() {
+        return new Callable<Auth0Exception>() {
             @Override
-            public Throwable call() throws Exception {
+            public Auth0Exception call() throws Exception {
                 return error;
             }
         };


### PR DESCRIPTION
Add a method execute() to all the requests. 
It's the equivalent to start() but this method blocks the current thread until the response is received, then returns the parsed response object.
In case of error this methods throws a Auth0Exception (the same that would have been used in the callback's onFailure)

Include tests for all async tests